### PR TITLE
type scoreWord and shortScoreWord as ReactNode

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, CSSProperties } from 'react';
+import React, { Fragment, CSSProperties, ReactNode } from 'react';
 import zxcvbn from 'zxcvbn';
 
 // components
@@ -17,9 +17,9 @@ export interface PasswordStrengthBarProps {
   password: string;
   userInputs?: string[];
   barColors?: string[];
-  scoreWords?: string[];
+  scoreWords?: ReactNode[];
   minLength?: number;
-  shortScoreWord?: string;
+  shortScoreWord?: ReactNode;
   onChangeScore?: (score: number, feedback: PasswordFeedback) => void;
 }
 


### PR DESCRIPTION
Accepting any ReactNode as scoreWord and shortScoreWord prop allows for more flexibility (e.g. adding icons or individual styles). Ignoring the types, this is actually already possible with no code change needed.

In my use case, I use this to style the shortScoreWord red and add a warning icon.